### PR TITLE
fix: strip extra fields for supabase expense requests

### DIFF
--- a/features/admin/Pages/SalesExpenses/index.tsx
+++ b/features/admin/Pages/SalesExpenses/index.tsx
@@ -54,10 +54,17 @@ export default function SalesExpensesPage() {
     try {
       const table = viewState.includes("sale") ? "sales" : "expenses";
 
+      // Clean up frontend-only camelCase fields to avoid Supabase column errors
+      const dbPayload = { ...data };
+      if (table === "expenses") {
+        delete (dbPayload as any).isBadDebt;
+        delete (dbPayload as any).badDebtReference;
+      }
+
       if (editingItem) {
         const { error } = await supabase
           .from(table)
-          .update(data)
+          .update(dbPayload)
           .eq("id", editingItem.id);
 
         if (error) throw error;
@@ -72,7 +79,7 @@ export default function SalesExpensesPage() {
         toast.success(`${table === "sales" ? "Sale" : "Expense"} updated successfully`);
         // Note: we DO NOT reset pagination here to keep the user on their current page/filter
       } else {
-        const { data: insertedData, error } = await supabase.from(table).insert([data]).select().single();
+        const { data: insertedData, error } = await supabase.from(table).insert([dbPayload]).select().single();
         if (error) throw error;
 
         logActivity({


### PR DESCRIPTION
create a cleaned database payload by removing isBadDebt and badDebtReference frontend-only fields for expense table requests, then use this payload for both Supabase insert and update operations to avoid column not found errors

## Description

Please include a summary of the changes and the related issue or feature request. Also include any relevant issue numbers.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have run `npm run lint` and ensured there are no linting errors.
- [ ] I have added necessary documentation (if applicable).
- [ ] I have reviewed my own code, ensuring it is clear and well-documented.
- [ ] Any dependent changes have been merged and published.

## Screenshots (if applicable)

If the PR includes changes that affect the UI, include screenshots that show the updated UI.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions for others to reproduce.

## Additional Comments

Add any other comments or information here, including potential risks or areas to watch closely.
